### PR TITLE
hotfix for failing get_video_info api

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cordova plugin add https://github.com/JonSmart/CordovaYoutubeVideoPlayer
 YoutubeVideoPlayer.openVideo('YOUTUBE_VIDEO_ID', function(result) { console.log('YoutubeVideoPlayer result = ' + result); });
 ```
 
-For Android 5.0+ you will need to add the following to config.xml
+For Android 5.0+ and iOS you will need to add the following to config.xml
 
 ```xml
 <preference name="YouTubeDataApiKey" value="[YOUR YOUTUBE API]" />

--- a/platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/YoutubeVideoPlayer.m
+++ b/platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/YoutubeVideoPlayer.m
@@ -8,8 +8,18 @@
 #import "YoutubeVideoPlayer.h"
 #import "XCDYouTubeKit.h"
 #import <AVKit/AVKit.h>
+#import <Cordova/NSDictionary+CordovaPreferences.h>
 
 @implementation YoutubeVideoPlayer
+
+- (void)pluginInitialize
+{
+    NSString *api_key = [self.commandDelegate.settings cordovaSettingForKey:@"YouTubeDataApiKey"];
+
+    if (api_key != nil) {
+        [XCDYouTubeClient setInnertubeApiKey: api_key];
+    }
+}
 
 - (void)openVideo:(CDVInvokedUrlCommand*)command
 {

--- a/plugin.xml
+++ b/plugin.xml
@@ -61,7 +61,7 @@
                     <source url="https://github.com/CocoaPods/Specs.git"/>
                 </config>
                 <pods use-frameworks="true">
-                    <pod name="XCDYouTubeKit" git="https://github.com/armendh/XCDYouTubeKit.git" branch="patch-2"/>
+                    <pod name="XCDYouTubeKit" git="https://github.com/armendh/XCDYouTubeKit.git" branch="master"/>
                 </pods>
             </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-youtube-video-player" version="2.4.0">
+<plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="cordova-plugin-youtube-video-player" version="2.4.1">
 
     <name>CordovaYoutubeVideoPlayer</name>
 
@@ -56,8 +56,15 @@
                 </feature>
             </config-file>
 
-            
-            <framework src="XCDYouTubeKit" type="podspec" spec="~> 2.7" />
+            <podspec>
+                <config>
+                    <source url="https://github.com/CocoaPods/Specs.git"/>
+                </config>
+                <pods use-frameworks="true">
+                    <pod name="XCDYouTubeKit" git="https://github.com/armendh/XCDYouTubeKit.git" branch="patch-2"/>
+                </pods>
+            </podspec>
+
             <header-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/YoutubeVideoPlayer.h"/>
             <source-file src="platforms/ios/YoutubeVideoPlayerProject/Plugins/com.bunkerpalace.cordova.YoutubeVideoPlayer/YoutubeVideoPlayer.m"/>
 


### PR DESCRIPTION
As described in https://github.com/0xced/XCDYouTubeKit/issues/534 Youtube seems to have changed the get_video_info api endpoint. This has not been fixed in XCDYouTubeKit yet, so this hotfix references another XCDYouTubeKit version.